### PR TITLE
Use 127.0.0.1 instead of localhost for mikro-orm, and update document…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ God, am I getting tired of typing that.
 ## Server Setup
 
 1. Create `server/.env` file
-1. Add `MONGODB_URI` environment variable (you will need to set up MongoDB somehow) [default: `mongodb://localhost:27017/`]
+1. Add `MONGODB_URI` environment variable (you will need to set up MongoDB somehow) [default: `mongodb://127.0.0.1:27017`] Note the use of `127.0.0.1` instead of `localhost`, as `localhost` appears to not work. 
 1. Add `JWT_SECRET` environment variable (set to any string) [default: `supersecret`]
 
 ### Optional Server Environment Variables

--- a/server/src/config/mikro-orm-config.ts
+++ b/server/src/config/mikro-orm-config.ts
@@ -14,7 +14,7 @@ function mikroOrmConfigFactory(
 ): MikroOrmModuleOptions {
   const mongoUrl = configService.get<string>(
     'MONGODB_URI',
-    'mongodb://localhost:27017',
+    'mongodb://127.0.0.1:27017',
   );
 
   return {


### PR DESCRIPTION
…ation

# Description

Fixes #16 
Updated the mikro-orm reference to localhost to use 127.0.0.1, and updated documentation with the new default and a warning about using localhost. 

Verified that the default being 'localhost' is still bugged, and that the default being '127.0.0.1' works.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works