### PR TITLE
Default choices to 0 to prevent NaN arrays

### DIFF
--- a/server/src/modules/player/gameplay.service.ts
+++ b/server/src/modules/player/gameplay.service.ts
@@ -61,22 +61,27 @@ export class GameplayService {
     if (foundLocation) {
       const choices = [
         ...createFilledArray(
-          this.constantsService.wavePercentBoost + foundLocation.baseStats.wave | 0,
+          (this.constantsService.wavePercentBoost +
+            foundLocation.baseStats.wave) |
+            0,
           'Wave',
         ),
         ...createFilledArray(
-          this.constantsService.locationFindPercentBoost +
-            foundLocation.baseStats.locationFind | 0,
+          (this.constantsService.locationFindPercentBoost +
+            foundLocation.baseStats.locationFind) |
+            0,
           'Discovery',
         ),
         ...createFilledArray(
-          this.constantsService.itemFindPercentBoost +
-            foundLocation.baseStats.itemFind | 0,
+          (this.constantsService.itemFindPercentBoost +
+            foundLocation.baseStats.itemFind) |
+            0,
           'Item',
         ),
         ...createFilledArray(
-          this.constantsService.collectibleFindPercentBoost +
-            foundLocation.baseStats.collectibleFind | 0,
+          (this.constantsService.collectibleFindPercentBoost +
+            foundLocation.baseStats.collectibleFind) |
+            0,
           'Collectible',
         ),
       ];


### PR DESCRIPTION
# Description

Getting an error trying to explore
![image](https://github.com/After-the-End-of-All-Things/game/assets/6930354/6eb70836-33ce-48e0-ad3e-39bf8d636545)
Turns out 
createFilledArray(
          this.constantsService.wavePercentBoost + foundLocation.baseStats.wave,
          'Wave',
        )
is trying to create an array of size NaN. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works