### PR TITLE
Block changing portrait if the user has not unlocked it

### DIFF
--- a/server/src/modules/player/player.controller.ts
+++ b/server/src/modules/player/player.controller.ts
@@ -4,20 +4,39 @@ import { PlayerService } from '@modules/player/player.service';
 import { Body, Controller, Patch, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { User } from '@utils/user.decorator';
+import { DiscoveriesService } from '@modules/discoveries/discoveries.service';
+import { NotFoundException } from '@nestjs/common';
 
 @ApiBearerAuth()
 @Controller('player')
 export class PlayerController {
-  constructor(private readonly playerService: PlayerService) {}
+  constructor(
+    private readonly playerService: PlayerService,
+    private readonly discoveriesService: DiscoveriesService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Get the online users count' })
+  @ApiOperation({ summary: 'Change Player Portrait' })
   @Patch('cosmetics/portrait')
   async changePortrait(
     @User() user,
     @Body('portrait') portrait: number,
   ): Promise<Partial<IFullUser | IPatchUser>> {
     const portraitId = Math.round(Math.min(107, Math.max(0, portrait)));
+
+    // Fetch the player's discoveries
+    const discoveries = await this.discoveriesService.getDiscoveriesForUser(
+      user.userId,
+    );
+
+    if (!discoveries) {
+      throw new NotFoundException('Discoveries not found for this user.');
+    }
+
+    // Check if the portrait is unlocked
+    if (!discoveries.portraits[portraitId.toString()]) {
+      throw new NotFoundException(`Portrait ${portraitId} is not unlocked.`);
+    }
 
     return this.playerService.updatePortraitForPlayer(user.userId, portraitId);
   }


### PR DESCRIPTION
# Description

Verification steps:
Inspect a locked portrait, delete 'disabled' from the properties on that ion-avatar
![image](https://github.com/After-the-End-of-All-Things/game/assets/6930354/3072e1ea-88bd-4d06-9f41-498a0dd6910e)
Select newly unlocked avatar and hit confirm
The following error should pop up:
![image](https://github.com/After-the-End-of-All-Things/game/assets/6930354/49d4e8ef-c074-43df-9673-aba49baf4135)

Fixes #9 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works