### PR TITLE
Fix percent completion on portrait and background collection page

### DIFF
--- a/client/src/app/pages/collections/collections.page.html
+++ b/client/src/app/pages/collections/collections.page.html
@@ -512,8 +512,8 @@
         </span>
 
         <span class="percent">
-          ({{ unlocked['portraits'] ?? 0 / contentService.maxPortraits | percent
-          }})
+          ({{ (((unlocked['portraits'] ?? 0) / contentService.maxPortraits) *
+          100) | number:'1.0-2' }}%)
         </span>
       </ion-col>
     </ion-row>
@@ -541,8 +541,8 @@
         </span>
 
         <span class="percent">
-          ({{ unlocked['backgrounds'] ?? 0 / contentService.maxBackgrounds |
-          percent }})
+          ({{ (((unlocked['backgrounds'] ?? 0) / contentService.maxPortraits) *
+          100) | number:'1.0-2' }}%)
         </span>
       </ion-col>
     </ion-row>


### PR DESCRIPTION
# Description

https://github.com/After-the-End-of-All-Things/game/issues/152

Fix display for % completed on portrait and background collection page

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings